### PR TITLE
iOSContentAvailable now removes sound and badge

### DIFF
--- a/clover.xml
+++ b/clover.xml
@@ -1,33 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1475583954">
-  <project timestamp="1475583954">
+<coverage generated="1477677944">
+  <project timestamp="1477677944">
     <package name="Nodes\Push\Exceptions">
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Exceptions/ApplicationNotFoundException.php">
         <class name="ApplicationNotFoundException" namespace="Nodes\Push\Exceptions">
-          <metrics complexity="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
+          <metrics complexity="1" methods="1" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="0" elements="3" coveredelements="0"/>
         </class>
-        <line num="18" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="2"/>
-        <line num="20" type="stmt" count="2"/>
-        <line num="21" type="stmt" count="2"/>
-        <metrics loc="22" ncloc="13" classes="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
+        <line num="18" type="method" name="__construct" visibility="public" complexity="1" crap="2" count="0"/>
+        <line num="20" type="stmt" count="0"/>
+        <line num="21" type="stmt" count="0"/>
+        <metrics loc="22" ncloc="13" classes="1" methods="1" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="0" elements="3" coveredelements="0"/>
       </file>
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Exceptions/ConfigErrorException.php">
         <class name="ConfigErrorException" namespace="Nodes\Push\Exceptions">
-          <metrics complexity="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
+          <metrics complexity="1" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
         </class>
-        <line num="18" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="5"/>
-        <line num="20" type="stmt" count="5"/>
-        <line num="21" type="stmt" count="5"/>
-        <metrics loc="22" ncloc="13" classes="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
+        <metrics loc="22" ncloc="13" classes="1" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
       </file>
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Exceptions/InvalidArgumentException.php">
         <class name="InvalidArgumentException" namespace="Nodes\Push\Exceptions">
-          <metrics complexity="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
+          <metrics complexity="1" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
         </class>
-        <line num="18" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="13"/>
-        <line num="20" type="stmt" count="13"/>
-        <line num="21" type="stmt" count="13"/>
-        <metrics loc="22" ncloc="13" classes="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
+        <metrics loc="22" ncloc="13" classes="1" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
       </file>
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Exceptions/InvalidPushProviderException.php">
         <class name="InvalidPushProviderException" namespace="Nodes\Push\Exceptions">
@@ -37,12 +31,9 @@
       </file>
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Exceptions/MissingArgumentException.php">
         <class name="MissingArgumentException" namespace="Nodes\Push\Exceptions">
-          <metrics complexity="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
+          <metrics complexity="1" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
         </class>
-        <line num="18" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="20" type="stmt" count="1"/>
-        <line num="21" type="stmt" count="1"/>
-        <metrics loc="22" ncloc="13" classes="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
+        <metrics loc="22" ncloc="13" classes="1" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
       </file>
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Exceptions/PushSizeLimitException.php">
         <class name="PushSizeLimitException" namespace="Nodes\Push\Exceptions">
@@ -52,280 +43,212 @@
       </file>
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Exceptions/SendPushFailedException.php">
         <class name="SendPushFailedException" namespace="Nodes\Push\Exceptions">
-          <metrics complexity="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
+          <metrics complexity="1" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
         </class>
-        <line num="18" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="20" type="stmt" count="1"/>
-        <line num="21" type="stmt" count="1"/>
-        <metrics loc="22" ncloc="13" classes="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
+        <metrics loc="22" ncloc="13" classes="1" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
       </file>
     </package>
     <package name="Nodes\Push\Providers">
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Providers/AbstractProvider.php">
         <class name="AbstractProvider" namespace="Nodes\Push\Providers">
-          <metrics complexity="54" methods="31" coveredmethods="30" conditionals="0" coveredconditionals="0" statements="104" coveredstatements="102" elements="135" coveredelements="132"/>
+          <metrics complexity="54" methods="31" coveredmethods="12" conditionals="0" coveredconditionals="0" statements="104" coveredstatements="23" elements="135" coveredelements="35"/>
         </class>
-        <line num="141" type="method" name="__construct" visibility="public" complexity="7" crap="7" count="75"/>
-        <line num="144" type="stmt" count="75"/>
-        <line num="145" type="stmt" count="2"/>
-        <line num="148" type="stmt" count="73"/>
-        <line num="149" type="stmt" count="1"/>
-        <line num="152" type="stmt" count="72"/>
-        <line num="154" type="stmt" count="72"/>
-        <line num="155" type="stmt" count="1"/>
-        <line num="158" type="stmt" count="71"/>
-        <line num="159" type="stmt" count="1"/>
-        <line num="162" type="stmt" count="70"/>
-        <line num="164" type="stmt" count="70"/>
-        <line num="165" type="stmt" count="1"/>
-        <line num="168" type="stmt" count="70"/>
-        <line num="169" type="stmt" count="1"/>
-        <line num="170" type="stmt" count="1"/>
-        <line num="172" type="stmt" count="69"/>
-        <line num="184" type="method" name="setAppGroup" visibility="public" complexity="2" crap="2" count="2"/>
-        <line num="186" type="stmt" count="2"/>
-        <line num="187" type="stmt" count="1"/>
-        <line num="188" type="stmt" count="1"/>
-        <line num="191" type="stmt" count="1"/>
-        <line num="193" type="stmt" count="1"/>
-        <line num="202" type="method" name="getAppGroup" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="204" type="stmt" count="1"/>
-        <line num="218" type="method" name="setChannels" visibility="public" complexity="2" crap="2" count="2"/>
-        <line num="221" type="stmt" count="2"/>
-        <line num="222" type="stmt" count="2"/>
-        <line num="225" type="stmt" count="1"/>
-        <line num="227" type="stmt" count="1"/>
-        <line num="239" type="method" name="setChannel" visibility="public" complexity="1" crap="1" count="2"/>
-        <line num="241" type="stmt" count="2"/>
-        <line num="243" type="stmt" count="2"/>
-        <line num="252" type="method" name="getChannels" visibility="public" complexity="1" crap="1" count="15"/>
-        <line num="254" type="stmt" count="15"/>
-        <line num="268" type="method" name="setAliases" visibility="public" complexity="2" crap="2" count="2"/>
-        <line num="271" type="stmt" count="2"/>
-        <line num="272" type="stmt" count="2"/>
-        <line num="275" type="stmt" count="1"/>
-        <line num="277" type="stmt" count="1"/>
-        <line num="290" type="method" name="setAlias" visibility="public" complexity="1" crap="1" count="2"/>
-        <line num="292" type="stmt" count="2"/>
-        <line num="294" type="stmt" count="2"/>
-        <line num="303" type="method" name="getAliases" visibility="public" complexity="1" crap="1" count="15"/>
-        <line num="305" type="stmt" count="15"/>
-        <line num="317" type="method" name="setMessage" visibility="public" complexity="1" crap="1" count="6"/>
-        <line num="319" type="stmt" count="6"/>
-        <line num="321" type="stmt" count="6"/>
-        <line num="330" type="method" name="getMessage" visibility="public" complexity="1" crap="1" count="15"/>
-        <line num="332" type="stmt" count="15"/>
-        <line num="347" type="method" name="setExtra" visibility="public" complexity="1" crap="1" count="6"/>
-        <line num="349" type="stmt" count="6"/>
-        <line num="351" type="stmt" count="4"/>
-        <line num="353" type="stmt" count="4"/>
-        <line num="366" type="method" name="validateExtra" visibility="protected" complexity="4" crap="4" count="8"/>
-        <line num="368" type="stmt" count="8"/>
-        <line num="371" type="stmt" count="8"/>
-        <line num="372" type="stmt" count="8"/>
-        <line num="373" type="stmt" count="2"/>
-        <line num="376" type="stmt" count="6"/>
-        <line num="377" type="stmt" count="6"/>
-        <line num="380" type="stmt" count="6"/>
-        <line num="393" type="method" name="setAndroidData" visibility="public" complexity="1" crap="1" count="3"/>
-        <line num="395" type="stmt" count="3"/>
-        <line num="397" type="stmt" count="3"/>
-        <line num="399" type="stmt" count="3"/>
-        <line num="408" type="method" name="getAndroidData" visibility="public" complexity="1" crap="1" count="2"/>
-        <line num="410" type="stmt" count="2"/>
-        <line num="419" type="method" name="getExtra" visibility="public" complexity="1" crap="1" count="14"/>
-        <line num="421" type="stmt" count="14"/>
-        <line num="434" type="method" name="setIOSBadge" visibility="public" complexity="2" crap="2" count="5"/>
-        <line num="436" type="stmt" count="5"/>
-        <line num="437" type="stmt" count="2"/>
-        <line num="440" type="stmt" count="3"/>
-        <line num="442" type="stmt" count="3"/>
-        <line num="451" type="method" name="getIOSBadge" visibility="public" complexity="1" crap="1" count="23"/>
-        <line num="453" type="stmt" count="23"/>
-        <line num="466" type="method" name="setSound" visibility="public" complexity="1" crap="1" count="3"/>
-        <line num="468" type="stmt" count="3"/>
-        <line num="470" type="stmt" count="3"/>
-        <line num="479" type="method" name="removeSound" visibility="public" complexity="1" crap="1" count="10"/>
-        <line num="481" type="stmt" count="10"/>
-        <line num="483" type="stmt" count="10"/>
-        <line num="492" type="method" name="getSound" visibility="public" complexity="1" crap="1" count="15"/>
-        <line num="494" type="stmt" count="15"/>
-        <line num="506" type="method" name="setIosContentAvailable" visibility="public" complexity="1" crap="1" count="2"/>
-        <line num="508" type="stmt" count="2"/>
-        <line num="510" type="stmt" count="2"/>
-        <line num="519" type="method" name="isIosContentAvailable" visibility="public" complexity="1" crap="1" count="14"/>
-        <line num="521" type="stmt" count="14"/>
-        <line num="531" type="method" name="setAndroidDeliveryPriorityNormal" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="533" type="stmt" count="1"/>
-        <line num="535" type="stmt" count="1"/>
-        <line num="545" type="method" name="setAndroidDeliveryPriorityHigh" visibility="public" complexity="1" crap="1" count="2"/>
-        <line num="547" type="stmt" count="2"/>
-        <line num="549" type="stmt" count="2"/>
-        <line num="559" type="method" name="getAndroidDeliveryPriority" visibility="public" complexity="1" crap="1" count="15"/>
-        <line num="561" type="stmt" count="15"/>
-        <line num="570" type="method" name="getInstance" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="572" type="stmt" count="1"/>
-        <line num="582" type="method" name="getAndroidVisibility" visibility="public" complexity="1" crap="1" count="15"/>
-        <line num="584" type="stmt" count="15"/>
-        <line num="600" type="method" name="setAndroidVisibility" visibility="public" complexity="2" crap="2" count="2"/>
-        <line num="603" type="stmt" count="2"/>
-        <line num="604" type="stmt" count="2"/>
-        <line num="605" type="stmt" count="2"/>
-        <line num="608" type="stmt" count="2"/>
-        <line num="609" type="stmt" count="1"/>
-        <line num="612" type="stmt" count="1"/>
-        <line num="614" type="stmt" count="1"/>
-        <line num="644" type="method" name="setAndroidStyle" visibility="public" complexity="10" crap="10.08" count="7"/>
-        <line num="647" type="stmt" count="7"/>
-        <line num="648" type="stmt" count="7"/>
-        <line num="649" type="stmt" count="7"/>
-        <line num="652" type="stmt" count="7"/>
-        <line num="653" type="stmt" count="1"/>
-        <line num="656" type="stmt" count="6"/>
-        <line num="659" type="stmt" count="6"/>
-        <line num="661" type="stmt" count="4"/>
-        <line num="662" type="stmt" count="4"/>
-        <line num="667" type="stmt" count="2"/>
-        <line num="668" type="stmt" count="1"/>
-        <line num="671" type="stmt" count="1"/>
-        <line num="672" type="stmt" count="1"/>
-        <line num="673" type="stmt" count="1"/>
-        <line num="682" type="stmt" count="3"/>
-        <line num="683" type="stmt" count="3"/>
-        <line num="688" type="stmt" count="3"/>
+        <line num="141" type="method" name="__construct" visibility="public" complexity="7" crap="11.10" count="1"/>
+        <line num="144" type="stmt" count="1"/>
+        <line num="145" type="stmt" count="0"/>
+        <line num="148" type="stmt" count="1"/>
+        <line num="149" type="stmt" count="0"/>
+        <line num="152" type="stmt" count="1"/>
+        <line num="154" type="stmt" count="1"/>
+        <line num="155" type="stmt" count="0"/>
+        <line num="158" type="stmt" count="1"/>
+        <line num="159" type="stmt" count="0"/>
+        <line num="162" type="stmt" count="1"/>
+        <line num="164" type="stmt" count="1"/>
+        <line num="165" type="stmt" count="0"/>
+        <line num="168" type="stmt" count="1"/>
+        <line num="169" type="stmt" count="0"/>
+        <line num="170" type="stmt" count="0"/>
+        <line num="172" type="stmt" count="1"/>
+        <line num="184" type="method" name="setAppGroup" visibility="public" complexity="2" crap="6" count="0"/>
+        <line num="186" type="stmt" count="0"/>
+        <line num="187" type="stmt" count="0"/>
+        <line num="188" type="stmt" count="0"/>
+        <line num="191" type="stmt" count="0"/>
+        <line num="193" type="stmt" count="0"/>
+        <line num="202" type="method" name="getAppGroup" visibility="public" complexity="1" crap="2" count="0"/>
+        <line num="204" type="stmt" count="0"/>
+        <line num="218" type="method" name="setChannels" visibility="public" complexity="2" crap="6" count="0"/>
+        <line num="221" type="stmt" count="0"/>
+        <line num="222" type="stmt" count="0"/>
+        <line num="225" type="stmt" count="0"/>
+        <line num="227" type="stmt" count="0"/>
+        <line num="239" type="method" name="setChannel" visibility="public" complexity="1" crap="2" count="0"/>
+        <line num="241" type="stmt" count="0"/>
+        <line num="243" type="stmt" count="0"/>
+        <line num="252" type="method" name="getChannels" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="254" type="stmt" count="1"/>
+        <line num="268" type="method" name="setAliases" visibility="public" complexity="2" crap="6" count="0"/>
+        <line num="271" type="stmt" count="0"/>
+        <line num="272" type="stmt" count="0"/>
+        <line num="275" type="stmt" count="0"/>
+        <line num="277" type="stmt" count="0"/>
+        <line num="290" type="method" name="setAlias" visibility="public" complexity="1" crap="2" count="0"/>
+        <line num="292" type="stmt" count="0"/>
+        <line num="294" type="stmt" count="0"/>
+        <line num="303" type="method" name="getAliases" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="305" type="stmt" count="1"/>
+        <line num="317" type="method" name="setMessage" visibility="public" complexity="1" crap="2" count="0"/>
+        <line num="319" type="stmt" count="0"/>
+        <line num="321" type="stmt" count="0"/>
+        <line num="330" type="method" name="getMessage" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="332" type="stmt" count="1"/>
+        <line num="347" type="method" name="setExtra" visibility="public" complexity="1" crap="2" count="0"/>
+        <line num="349" type="stmt" count="0"/>
+        <line num="351" type="stmt" count="0"/>
+        <line num="353" type="stmt" count="0"/>
+        <line num="366" type="method" name="validateExtra" visibility="protected" complexity="4" crap="20" count="0"/>
+        <line num="368" type="stmt" count="0"/>
+        <line num="371" type="stmt" count="0"/>
+        <line num="372" type="stmt" count="0"/>
+        <line num="373" type="stmt" count="0"/>
+        <line num="376" type="stmt" count="0"/>
+        <line num="377" type="stmt" count="0"/>
+        <line num="380" type="stmt" count="0"/>
+        <line num="393" type="method" name="setAndroidData" visibility="public" complexity="1" crap="2" count="0"/>
+        <line num="395" type="stmt" count="0"/>
+        <line num="397" type="stmt" count="0"/>
+        <line num="399" type="stmt" count="0"/>
+        <line num="408" type="method" name="getAndroidData" visibility="public" complexity="1" crap="2" count="0"/>
+        <line num="410" type="stmt" count="0"/>
+        <line num="419" type="method" name="getExtra" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="421" type="stmt" count="1"/>
+        <line num="434" type="method" name="setIOSBadge" visibility="public" complexity="2" crap="6" count="0"/>
+        <line num="436" type="stmt" count="0"/>
+        <line num="437" type="stmt" count="0"/>
+        <line num="440" type="stmt" count="0"/>
+        <line num="442" type="stmt" count="0"/>
+        <line num="451" type="method" name="getIOSBadge" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="453" type="stmt" count="1"/>
+        <line num="466" type="method" name="setSound" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="468" type="stmt" count="1"/>
+        <line num="470" type="stmt" count="1"/>
+        <line num="479" type="method" name="removeSound" visibility="public" complexity="1" crap="2" count="0"/>
+        <line num="481" type="stmt" count="0"/>
+        <line num="483" type="stmt" count="0"/>
+        <line num="492" type="method" name="getSound" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="494" type="stmt" count="1"/>
+        <line num="506" type="method" name="setIosContentAvailable" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="508" type="stmt" count="1"/>
+        <line num="510" type="stmt" count="1"/>
+        <line num="519" type="method" name="isIosContentAvailable" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="521" type="stmt" count="1"/>
+        <line num="531" type="method" name="setAndroidDeliveryPriorityNormal" visibility="public" complexity="1" crap="2" count="0"/>
+        <line num="533" type="stmt" count="0"/>
+        <line num="535" type="stmt" count="0"/>
+        <line num="545" type="method" name="setAndroidDeliveryPriorityHigh" visibility="public" complexity="1" crap="2" count="0"/>
+        <line num="547" type="stmt" count="0"/>
+        <line num="549" type="stmt" count="0"/>
+        <line num="559" type="method" name="getAndroidDeliveryPriority" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="561" type="stmt" count="1"/>
+        <line num="570" type="method" name="getInstance" visibility="public" complexity="1" crap="2" count="0"/>
+        <line num="572" type="stmt" count="0"/>
+        <line num="582" type="method" name="getAndroidVisibility" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="584" type="stmt" count="1"/>
+        <line num="600" type="method" name="setAndroidVisibility" visibility="public" complexity="2" crap="6" count="0"/>
+        <line num="603" type="stmt" count="0"/>
+        <line num="604" type="stmt" count="0"/>
+        <line num="605" type="stmt" count="0"/>
+        <line num="608" type="stmt" count="0"/>
+        <line num="609" type="stmt" count="0"/>
+        <line num="612" type="stmt" count="0"/>
+        <line num="614" type="stmt" count="0"/>
+        <line num="644" type="method" name="setAndroidStyle" visibility="public" complexity="10" crap="110" count="0"/>
+        <line num="647" type="stmt" count="0"/>
+        <line num="648" type="stmt" count="0"/>
+        <line num="649" type="stmt" count="0"/>
+        <line num="652" type="stmt" count="0"/>
+        <line num="653" type="stmt" count="0"/>
+        <line num="656" type="stmt" count="0"/>
+        <line num="659" type="stmt" count="0"/>
+        <line num="660" type="stmt" count="0"/>
+        <line num="661" type="stmt" count="0"/>
+        <line num="664" type="stmt" count="0"/>
+        <line num="665" type="stmt" count="0"/>
+        <line num="668" type="stmt" count="0"/>
+        <line num="669" type="stmt" count="0"/>
+        <line num="670" type="stmt" count="0"/>
+        <line num="678" type="stmt" count="0"/>
+        <line num="679" type="stmt" count="0"/>
+        <line num="684" type="stmt" count="0"/>
+        <line num="685" type="stmt" count="0"/>
         <line num="689" type="stmt" count="0"/>
-        <line num="693" type="stmt" count="3"/>
-        <line num="694" type="stmt" count="0"/>
-        <line num="697" type="stmt" count="3"/>
-        <line num="699" type="stmt" count="3"/>
-        <line num="709" type="method" name="getAndroidStyle" visibility="public" complexity="1" crap="1" count="17"/>
-        <line num="711" type="stmt" count="17"/>
-        <metrics loc="713" ncloc="338" classes="1" methods="31" coveredmethods="30" conditionals="0" coveredconditionals="0" statements="104" coveredstatements="102" elements="135" coveredelements="132"/>
+        <line num="690" type="stmt" count="0"/>
+        <line num="693" type="stmt" count="0"/>
+        <line num="695" type="stmt" count="0"/>
+        <line num="705" type="method" name="getAndroidStyle" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="707" type="stmt" count="1"/>
+        <metrics loc="709" ncloc="334" classes="1" methods="31" coveredmethods="12" conditionals="0" coveredconditionals="0" statements="104" coveredstatements="23" elements="135" coveredelements="35"/>
       </file>
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Providers/UrbanAirshipV3.php">
         <class name="UrbanAirshipV3" namespace="Nodes\Push\Providers">
-          <metrics complexity="64" methods="15" coveredmethods="15" conditionals="0" coveredconditionals="0" statements="104" coveredstatements="104" elements="119" coveredelements="119"/>
+          <metrics complexity="64" methods="7" coveredmethods="7" conditionals="0" coveredconditionals="0" statements="47" coveredstatements="47" elements="54" coveredelements="54"/>
         </class>
-        <line num="37" type="method" name="setIOSBadge" visibility="public" complexity="9" crap="9" count="11"/>
-        <line num="40" type="stmt" count="11"/>
-        <line num="41" type="stmt" count="3"/>
-        <line num="44" type="stmt" count="11"/>
-        <line num="45" type="stmt" count="1"/>
-        <line num="48" type="stmt" count="10"/>
-        <line num="49" type="stmt" count="2"/>
-        <line num="52" type="stmt" count="8"/>
-        <line num="54" type="stmt" count="8"/>
-        <line num="67" type="method" name="setExtra" visibility="public" complexity="1" crap="1" count="4"/>
-        <line num="69" type="stmt" count="4"/>
-        <line num="71" type="stmt" count="3"/>
-        <line num="83" type="method" name="setAndroidData" visibility="public" complexity="1" crap="1" count="2"/>
-        <line num="85" type="stmt" count="2"/>
-        <line num="87" type="stmt" count="2"/>
-        <line num="98" type="method" name="validateExtra" visibility="protected" complexity="3" crap="3" count="5"/>
-        <line num="101" type="stmt" count="5"/>
-        <line num="106" type="stmt" count="5"/>
-        <line num="107" type="stmt" count="5"/>
-        <line num="108" type="stmt" count="5"/>
-        <line num="112" type="stmt" count="4"/>
-        <line num="113" type="stmt" count="4"/>
-        <line num="124" type="method" name="send" visibility="public" complexity="12" crap="12" count="5"/>
-        <line num="126" type="stmt" count="5"/>
-        <line num="128" type="stmt" count="4"/>
-        <line num="132" type="stmt" count="4"/>
-        <line num="135" type="stmt" count="4"/>
-        <line num="142" type="stmt" count="4"/>
-        <line num="143" type="stmt" count="4"/>
-        <line num="146" type="stmt" count="4"/>
-        <line num="147" type="stmt" count="1"/>
-        <line num="153" type="stmt" count="4"/>
-        <line num="156" type="stmt" count="3"/>
-        <line num="161" type="stmt" count="3"/>
-        <line num="164" type="stmt" count="3"/>
-        <line num="168" type="stmt" count="3"/>
-        <line num="169" type="stmt" count="1"/>
-        <line num="180" type="stmt" count="1"/>
-        <line num="181" type="stmt" count="4"/>
-        <line num="185" type="stmt" count="3"/>
-        <line num="196" type="method" name="validateBeforePush" visibility="protected" complexity="5" crap="5" count="5"/>
-        <line num="198" type="stmt" count="5"/>
-        <line num="199" type="stmt" count="1"/>
-        <line num="203" type="stmt" count="4"/>
-        <line num="207" type="stmt" count="4"/>
-        <line num="211" type="stmt" count="4"/>
-        <line num="214" type="stmt" count="4"/>
-        <line num="223" type="method" name="hasEmptyCredentials" visibility="protected" complexity="4" crap="4" count="4"/>
-        <line num="227" type="stmt" count="4"/>
-        <line num="228" type="stmt" count="4"/>
-        <line num="233" type="stmt" count="4"/>
-        <line num="242" type="method" name="getHttpClient" visibility="protected" complexity="2" crap="2" count="4"/>
-        <line num="244" type="stmt" count="4"/>
-        <line num="248" type="stmt" count="4"/>
-        <line num="249" type="stmt" count="4"/>
-        <line num="251" type="stmt" count="4"/>
-        <line num="252" type="stmt" count="4"/>
-        <line num="254" type="stmt" count="4"/>
-        <line num="264" type="method" name="buildPushData" visibility="protected" complexity="5" crap="5" count="13"/>
-        <line num="267" type="stmt" count="13"/>
-        <line num="270" type="stmt" count="13"/>
-        <line num="273" type="stmt" count="13"/>
-        <line num="276" type="stmt" count="13"/>
-        <line num="277" type="stmt" count="8"/>
-        <line num="281" type="stmt" count="13"/>
-        <line num="282" type="stmt" count="13"/>
-        <line num="286" type="stmt" count="13"/>
-        <line num="287" type="stmt" count="2"/>
-        <line num="291" type="stmt" count="13"/>
-        <line num="293" type="stmt" count="13"/>
-        <line num="302" type="method" name="buildAudienceData" visibility="protected" complexity="4" crap="4" count="13"/>
-        <line num="305" type="stmt" count="13"/>
-        <line num="308" type="stmt" count="13"/>
-        <line num="309" type="stmt" count="1"/>
-        <line num="313" type="stmt" count="13"/>
-        <line num="314" type="stmt" count="1"/>
-        <line num="315" type="stmt" count="1"/>
-        <line num="319" type="stmt" count="13"/>
-        <line num="328" type="method" name="buildIOSData" visibility="protected" complexity="5" crap="5" count="13"/>
-        <line num="331" type="stmt" count="13"/>
-        <line num="334" type="stmt" count="13"/>
-        <line num="335" type="stmt" count="2"/>
-        <line num="339" type="stmt" count="13"/>
+        <line num="37" type="method" name="setIOSBadge" visibility="public" complexity="9" crap="9" count="1"/>
+        <line num="40" type="stmt" count="1"/>
+        <line num="41" type="stmt" count="1"/>
+        <line num="44" type="stmt" count="1"/>
+        <line num="48" type="stmt" count="1"/>
+        <line num="52" type="stmt" count="1"/>
+        <line num="54" type="stmt" count="1"/>
+        <line num="264" type="method" name="buildPushData" visibility="protected" complexity="5" crap="5" count="1"/>
+        <line num="267" type="stmt" count="1"/>
+        <line num="270" type="stmt" count="1"/>
+        <line num="273" type="stmt" count="1"/>
+        <line num="276" type="stmt" count="1"/>
+        <line num="277" type="stmt" count="1"/>
+        <line num="281" type="stmt" count="1"/>
+        <line num="282" type="stmt" count="1"/>
+        <line num="286" type="stmt" count="1"/>
+        <line num="291" type="stmt" count="1"/>
+        <line num="293" type="stmt" count="1"/>
+        <line num="302" type="method" name="buildAudienceData" visibility="protected" complexity="4" crap="4" count="1"/>
+        <line num="305" type="stmt" count="1"/>
+        <line num="308" type="stmt" count="1"/>
+        <line num="313" type="stmt" count="1"/>
+        <line num="319" type="stmt" count="1"/>
+        <line num="328" type="method" name="buildIOSData" visibility="protected" complexity="5" crap="5" count="1"/>
+        <line num="331" type="stmt" count="1"/>
+        <line num="334" type="stmt" count="1"/>
+        <line num="339" type="stmt" count="1"/>
         <line num="340" type="stmt" count="1"/>
-        <line num="344" type="stmt" count="13"/>
-        <line num="345" type="stmt" count="5"/>
-        <line num="349" type="stmt" count="13"/>
+        <line num="344" type="stmt" count="1"/>
+        <line num="345" type="stmt" count="1"/>
+        <line num="349" type="stmt" count="1"/>
         <line num="350" type="stmt" count="1"/>
-        <line num="353" type="stmt" count="13"/>
-        <line num="362" type="method" name="buildAndroidData" visibility="protected" complexity="7" crap="7" count="13"/>
-        <line num="365" type="stmt" count="13"/>
-        <line num="368" type="stmt" count="13"/>
-        <line num="369" type="stmt" count="2"/>
-        <line num="373" type="stmt" count="13"/>
-        <line num="374" type="stmt" count="1"/>
-        <line num="377" type="stmt" count="1"/>
-        <line num="382" type="stmt" count="13"/>
-        <line num="383" type="stmt" count="5"/>
-        <line num="387" type="stmt" count="13"/>
-        <line num="388" type="stmt" count="1"/>
-        <line num="392" type="stmt" count="13"/>
-        <line num="395" type="stmt" count="13"/>
-        <line num="399" type="stmt" count="13"/>
-        <line num="408" type="method" name="buildWnsData" visibility="protected" complexity="3" crap="3" count="13"/>
-        <line num="411" type="stmt" count="13"/>
-        <line num="414" type="stmt" count="13"/>
-        <line num="417" type="stmt" count="13"/>
-        <line num="418" type="stmt" count="5"/>
-        <line num="424" type="stmt" count="13"/>
-        <line num="425" type="stmt" count="2"/>
-        <line num="426" type="stmt" count="2"/>
-        <line num="427" type="stmt" count="2"/>
-        <line num="430" type="stmt" count="13"/>
-        <line num="439" type="method" name="getRequestData" visibility="public" complexity="1" crap="1" count="9"/>
-        <line num="441" type="stmt" count="9"/>
-        <line num="451" type="method" name="setMessage" visibility="public" complexity="2" crap="2" count="5"/>
-        <line num="454" type="stmt" count="5"/>
-        <line num="455" type="stmt" count="1"/>
-        <line num="458" type="stmt" count="5"/>
-        <metrics loc="460" ncloc="259" classes="1" methods="15" coveredmethods="15" conditionals="0" coveredconditionals="0" statements="104" coveredstatements="104" elements="119" coveredelements="119"/>
+        <line num="351" type="stmt" count="1"/>
+        <line num="352" type="stmt" count="1"/>
+        <line num="355" type="stmt" count="1"/>
+        <line num="364" type="method" name="buildAndroidData" visibility="protected" complexity="7" crap="7" count="1"/>
+        <line num="367" type="stmt" count="1"/>
+        <line num="370" type="stmt" count="1"/>
+        <line num="375" type="stmt" count="1"/>
+        <line num="384" type="stmt" count="1"/>
+        <line num="385" type="stmt" count="1"/>
+        <line num="389" type="stmt" count="1"/>
+        <line num="394" type="stmt" count="1"/>
+        <line num="397" type="stmt" count="1"/>
+        <line num="401" type="stmt" count="1"/>
+        <line num="410" type="method" name="buildWnsData" visibility="protected" complexity="3" crap="3" count="1"/>
+        <line num="413" type="stmt" count="1"/>
+        <line num="416" type="stmt" count="1"/>
+        <line num="419" type="stmt" count="1"/>
+        <line num="420" type="stmt" count="1"/>
+        <line num="426" type="stmt" count="1"/>
+        <line num="432" type="stmt" count="1"/>
+        <line num="441" type="method" name="getRequestData" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="443" type="stmt" count="1"/>
+        <metrics loc="462" ncloc="261" classes="1" methods="7" coveredmethods="7" conditionals="0" coveredconditionals="0" statements="47" coveredstatements="47" elements="54" coveredelements="54"/>
       </file>
     </package>
     <package name="Nodes\Push">
@@ -333,39 +256,35 @@
         <class name="ServiceProvider" namespace="Nodes\Push">
           <metrics complexity="6" methods="5" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="10" coveredstatements="10" elements="15" coveredelements="15"/>
         </class>
-        <line num="20" type="method" name="boot" visibility="public" complexity="1" crap="1" count="75"/>
-        <line num="22" type="stmt" count="75"/>
-        <line num="23" type="stmt" count="75"/>
-        <line num="31" type="method" name="register" visibility="public" complexity="1" crap="1" count="75"/>
-        <line num="33" type="stmt" count="75"/>
-        <line num="34" type="stmt" count="75"/>
-        <line num="42" type="method" name="publishGroups" visibility="protected" complexity="1" crap="1" count="75"/>
-        <line num="45" type="stmt" count="75"/>
-        <line num="46" type="stmt" count="75"/>
-        <line num="47" type="stmt" count="75"/>
-        <line num="48" type="stmt" count="75"/>
-        <line num="56" type="method" name="registerPushProvider" visibility="protected" complexity="2" crap="2" count="75"/>
-        <line num="68" type="stmt" count="75"/>
-        <line num="70" type="method" name="anonymous function" complexity="1" crap="1" count="75"/>
-        <line num="72" type="stmt" count="75"/>
-        <line num="73" type="stmt" count="75"/>
+        <line num="20" type="method" name="boot" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="22" type="stmt" count="1"/>
+        <line num="23" type="stmt" count="1"/>
+        <line num="31" type="method" name="register" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="33" type="stmt" count="1"/>
+        <line num="34" type="stmt" count="1"/>
+        <line num="42" type="method" name="publishGroups" visibility="protected" complexity="1" crap="1" count="1"/>
+        <line num="45" type="stmt" count="1"/>
+        <line num="46" type="stmt" count="1"/>
+        <line num="47" type="stmt" count="1"/>
+        <line num="48" type="stmt" count="1"/>
+        <line num="56" type="method" name="registerPushProvider" visibility="protected" complexity="2" crap="2" count="1"/>
+        <line num="68" type="stmt" count="1"/>
+        <line num="70" type="method" name="anonymous function" complexity="1" crap="1" count="1"/>
+        <line num="72" type="stmt" count="1"/>
+        <line num="73" type="stmt" count="1"/>
         <metrics loc="87" ncloc="30" classes="1" methods="5" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="11" coveredstatements="11" elements="16" coveredelements="16"/>
       </file>
     </package>
     <package name="Nodes\Push\Support\Facades">
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Support/Facades/Push.php">
         <class name="Push" namespace="Nodes\Push\Support\Facades">
-          <metrics complexity="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="1" coveredstatements="1" elements="2" coveredelements="2"/>
+          <metrics complexity="1" methods="1" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="1" coveredstatements="0" elements="2" coveredelements="0"/>
         </class>
-        <line num="20" type="method" name="getFacadeAccessor" visibility="protected" complexity="1" crap="1" count="1"/>
-        <line num="22" type="stmt" count="1"/>
-        <metrics loc="24" ncloc="13" classes="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="1" coveredstatements="1" elements="2" coveredelements="2"/>
+        <line num="20" type="method" name="getFacadeAccessor" visibility="protected" complexity="1" crap="2" count="0"/>
+        <line num="22" type="stmt" count="0"/>
+        <metrics loc="24" ncloc="13" classes="1" methods="1" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="1" coveredstatements="0" elements="2" coveredelements="0"/>
       </file>
     </package>
-    <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Support/Helpers/Push.php">
-      <line num="14" type="stmt" count="1"/>
-      <metrics loc="16" ncloc="10" classes="0" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="1" coveredstatements="1" elements="1" coveredelements="1"/>
-    </file>
-    <metrics files="12" loc="1462" ncloc="749" classes="11" methods="57" coveredmethods="56" conditionals="0" coveredconditionals="0" statements="231" coveredstatements="229" elements="288" coveredelements="285"/>
+    <metrics files="11" loc="1444" ncloc="737" classes="11" methods="45" coveredmethods="24" conditionals="0" coveredconditionals="0" statements="165" coveredstatements="81" elements="210" coveredelements="105"/>
   </project>
 </coverage>

--- a/clover.xml
+++ b/clover.xml
@@ -1,27 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1477677944">
-  <project timestamp="1477677944">
+<coverage generated="1477678345">
+  <project timestamp="1477678345">
     <package name="Nodes\Push\Exceptions">
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Exceptions/ApplicationNotFoundException.php">
         <class name="ApplicationNotFoundException" namespace="Nodes\Push\Exceptions">
-          <metrics complexity="1" methods="1" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="0" elements="3" coveredelements="0"/>
+          <metrics complexity="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
         </class>
-        <line num="18" type="method" name="__construct" visibility="public" complexity="1" crap="2" count="0"/>
-        <line num="20" type="stmt" count="0"/>
-        <line num="21" type="stmt" count="0"/>
-        <metrics loc="22" ncloc="13" classes="1" methods="1" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="0" elements="3" coveredelements="0"/>
+        <line num="18" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="2"/>
+        <line num="20" type="stmt" count="2"/>
+        <line num="21" type="stmt" count="2"/>
+        <metrics loc="22" ncloc="13" classes="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
       </file>
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Exceptions/ConfigErrorException.php">
         <class name="ConfigErrorException" namespace="Nodes\Push\Exceptions">
-          <metrics complexity="1" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
+          <metrics complexity="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
         </class>
-        <metrics loc="22" ncloc="13" classes="1" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
+        <line num="18" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="5"/>
+        <line num="20" type="stmt" count="5"/>
+        <line num="21" type="stmt" count="5"/>
+        <metrics loc="22" ncloc="13" classes="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
       </file>
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Exceptions/InvalidArgumentException.php">
         <class name="InvalidArgumentException" namespace="Nodes\Push\Exceptions">
-          <metrics complexity="1" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
+          <metrics complexity="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
         </class>
-        <metrics loc="22" ncloc="13" classes="1" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
+        <line num="18" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="13"/>
+        <line num="20" type="stmt" count="13"/>
+        <line num="21" type="stmt" count="13"/>
+        <metrics loc="22" ncloc="13" classes="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
       </file>
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Exceptions/InvalidPushProviderException.php">
         <class name="InvalidPushProviderException" namespace="Nodes\Push\Exceptions">
@@ -31,9 +37,12 @@
       </file>
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Exceptions/MissingArgumentException.php">
         <class name="MissingArgumentException" namespace="Nodes\Push\Exceptions">
-          <metrics complexity="1" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
+          <metrics complexity="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
         </class>
-        <metrics loc="22" ncloc="13" classes="1" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
+        <line num="18" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="20" type="stmt" count="1"/>
+        <line num="21" type="stmt" count="1"/>
+        <metrics loc="22" ncloc="13" classes="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
       </file>
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Exceptions/PushSizeLimitException.php">
         <class name="PushSizeLimitException" namespace="Nodes\Push\Exceptions">
@@ -43,212 +52,282 @@
       </file>
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Exceptions/SendPushFailedException.php">
         <class name="SendPushFailedException" namespace="Nodes\Push\Exceptions">
-          <metrics complexity="1" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
+          <metrics complexity="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
         </class>
-        <metrics loc="22" ncloc="13" classes="1" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="0" coveredstatements="0" elements="0" coveredelements="0"/>
+        <line num="18" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="20" type="stmt" count="1"/>
+        <line num="21" type="stmt" count="1"/>
+        <metrics loc="22" ncloc="13" classes="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="2" coveredstatements="2" elements="3" coveredelements="3"/>
       </file>
     </package>
     <package name="Nodes\Push\Providers">
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Providers/AbstractProvider.php">
         <class name="AbstractProvider" namespace="Nodes\Push\Providers">
-          <metrics complexity="54" methods="31" coveredmethods="12" conditionals="0" coveredconditionals="0" statements="104" coveredstatements="23" elements="135" coveredelements="35"/>
+          <metrics complexity="54" methods="31" coveredmethods="30" conditionals="0" coveredconditionals="0" statements="104" coveredstatements="102" elements="135" coveredelements="132"/>
         </class>
-        <line num="141" type="method" name="__construct" visibility="public" complexity="7" crap="11.10" count="1"/>
-        <line num="144" type="stmt" count="1"/>
-        <line num="145" type="stmt" count="0"/>
-        <line num="148" type="stmt" count="1"/>
-        <line num="149" type="stmt" count="0"/>
-        <line num="152" type="stmt" count="1"/>
-        <line num="154" type="stmt" count="1"/>
-        <line num="155" type="stmt" count="0"/>
-        <line num="158" type="stmt" count="1"/>
-        <line num="159" type="stmt" count="0"/>
-        <line num="162" type="stmt" count="1"/>
-        <line num="164" type="stmt" count="1"/>
-        <line num="165" type="stmt" count="0"/>
-        <line num="168" type="stmt" count="1"/>
-        <line num="169" type="stmt" count="0"/>
-        <line num="170" type="stmt" count="0"/>
-        <line num="172" type="stmt" count="1"/>
-        <line num="184" type="method" name="setAppGroup" visibility="public" complexity="2" crap="6" count="0"/>
-        <line num="186" type="stmt" count="0"/>
-        <line num="187" type="stmt" count="0"/>
-        <line num="188" type="stmt" count="0"/>
-        <line num="191" type="stmt" count="0"/>
-        <line num="193" type="stmt" count="0"/>
-        <line num="202" type="method" name="getAppGroup" visibility="public" complexity="1" crap="2" count="0"/>
-        <line num="204" type="stmt" count="0"/>
-        <line num="218" type="method" name="setChannels" visibility="public" complexity="2" crap="6" count="0"/>
-        <line num="221" type="stmt" count="0"/>
-        <line num="222" type="stmt" count="0"/>
-        <line num="225" type="stmt" count="0"/>
-        <line num="227" type="stmt" count="0"/>
-        <line num="239" type="method" name="setChannel" visibility="public" complexity="1" crap="2" count="0"/>
-        <line num="241" type="stmt" count="0"/>
-        <line num="243" type="stmt" count="0"/>
-        <line num="252" type="method" name="getChannels" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="254" type="stmt" count="1"/>
-        <line num="268" type="method" name="setAliases" visibility="public" complexity="2" crap="6" count="0"/>
-        <line num="271" type="stmt" count="0"/>
-        <line num="272" type="stmt" count="0"/>
-        <line num="275" type="stmt" count="0"/>
-        <line num="277" type="stmt" count="0"/>
-        <line num="290" type="method" name="setAlias" visibility="public" complexity="1" crap="2" count="0"/>
-        <line num="292" type="stmt" count="0"/>
-        <line num="294" type="stmt" count="0"/>
-        <line num="303" type="method" name="getAliases" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="305" type="stmt" count="1"/>
-        <line num="317" type="method" name="setMessage" visibility="public" complexity="1" crap="2" count="0"/>
-        <line num="319" type="stmt" count="0"/>
-        <line num="321" type="stmt" count="0"/>
-        <line num="330" type="method" name="getMessage" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="332" type="stmt" count="1"/>
-        <line num="347" type="method" name="setExtra" visibility="public" complexity="1" crap="2" count="0"/>
-        <line num="349" type="stmt" count="0"/>
-        <line num="351" type="stmt" count="0"/>
-        <line num="353" type="stmt" count="0"/>
-        <line num="366" type="method" name="validateExtra" visibility="protected" complexity="4" crap="20" count="0"/>
-        <line num="368" type="stmt" count="0"/>
-        <line num="371" type="stmt" count="0"/>
-        <line num="372" type="stmt" count="0"/>
-        <line num="373" type="stmt" count="0"/>
-        <line num="376" type="stmt" count="0"/>
-        <line num="377" type="stmt" count="0"/>
-        <line num="380" type="stmt" count="0"/>
-        <line num="393" type="method" name="setAndroidData" visibility="public" complexity="1" crap="2" count="0"/>
-        <line num="395" type="stmt" count="0"/>
-        <line num="397" type="stmt" count="0"/>
-        <line num="399" type="stmt" count="0"/>
-        <line num="408" type="method" name="getAndroidData" visibility="public" complexity="1" crap="2" count="0"/>
-        <line num="410" type="stmt" count="0"/>
-        <line num="419" type="method" name="getExtra" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="421" type="stmt" count="1"/>
-        <line num="434" type="method" name="setIOSBadge" visibility="public" complexity="2" crap="6" count="0"/>
-        <line num="436" type="stmt" count="0"/>
-        <line num="437" type="stmt" count="0"/>
-        <line num="440" type="stmt" count="0"/>
-        <line num="442" type="stmt" count="0"/>
-        <line num="451" type="method" name="getIOSBadge" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="453" type="stmt" count="1"/>
-        <line num="466" type="method" name="setSound" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="468" type="stmt" count="1"/>
-        <line num="470" type="stmt" count="1"/>
-        <line num="479" type="method" name="removeSound" visibility="public" complexity="1" crap="2" count="0"/>
-        <line num="481" type="stmt" count="0"/>
-        <line num="483" type="stmt" count="0"/>
-        <line num="492" type="method" name="getSound" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="494" type="stmt" count="1"/>
-        <line num="506" type="method" name="setIosContentAvailable" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="508" type="stmt" count="1"/>
-        <line num="510" type="stmt" count="1"/>
-        <line num="519" type="method" name="isIosContentAvailable" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="521" type="stmt" count="1"/>
-        <line num="531" type="method" name="setAndroidDeliveryPriorityNormal" visibility="public" complexity="1" crap="2" count="0"/>
-        <line num="533" type="stmt" count="0"/>
-        <line num="535" type="stmt" count="0"/>
-        <line num="545" type="method" name="setAndroidDeliveryPriorityHigh" visibility="public" complexity="1" crap="2" count="0"/>
-        <line num="547" type="stmt" count="0"/>
-        <line num="549" type="stmt" count="0"/>
-        <line num="559" type="method" name="getAndroidDeliveryPriority" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="561" type="stmt" count="1"/>
-        <line num="570" type="method" name="getInstance" visibility="public" complexity="1" crap="2" count="0"/>
-        <line num="572" type="stmt" count="0"/>
-        <line num="582" type="method" name="getAndroidVisibility" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="584" type="stmt" count="1"/>
-        <line num="600" type="method" name="setAndroidVisibility" visibility="public" complexity="2" crap="6" count="0"/>
-        <line num="603" type="stmt" count="0"/>
-        <line num="604" type="stmt" count="0"/>
-        <line num="605" type="stmt" count="0"/>
-        <line num="608" type="stmt" count="0"/>
-        <line num="609" type="stmt" count="0"/>
-        <line num="612" type="stmt" count="0"/>
-        <line num="614" type="stmt" count="0"/>
-        <line num="644" type="method" name="setAndroidStyle" visibility="public" complexity="10" crap="110" count="0"/>
-        <line num="647" type="stmt" count="0"/>
-        <line num="648" type="stmt" count="0"/>
-        <line num="649" type="stmt" count="0"/>
-        <line num="652" type="stmt" count="0"/>
-        <line num="653" type="stmt" count="0"/>
-        <line num="656" type="stmt" count="0"/>
-        <line num="659" type="stmt" count="0"/>
-        <line num="660" type="stmt" count="0"/>
-        <line num="661" type="stmt" count="0"/>
-        <line num="664" type="stmt" count="0"/>
-        <line num="665" type="stmt" count="0"/>
-        <line num="668" type="stmt" count="0"/>
-        <line num="669" type="stmt" count="0"/>
-        <line num="670" type="stmt" count="0"/>
-        <line num="678" type="stmt" count="0"/>
-        <line num="679" type="stmt" count="0"/>
-        <line num="684" type="stmt" count="0"/>
+        <line num="141" type="method" name="__construct" visibility="public" complexity="7" crap="7" count="76"/>
+        <line num="144" type="stmt" count="76"/>
+        <line num="145" type="stmt" count="2"/>
+        <line num="148" type="stmt" count="74"/>
+        <line num="149" type="stmt" count="1"/>
+        <line num="152" type="stmt" count="73"/>
+        <line num="154" type="stmt" count="73"/>
+        <line num="155" type="stmt" count="1"/>
+        <line num="158" type="stmt" count="72"/>
+        <line num="159" type="stmt" count="1"/>
+        <line num="162" type="stmt" count="71"/>
+        <line num="164" type="stmt" count="71"/>
+        <line num="165" type="stmt" count="1"/>
+        <line num="168" type="stmt" count="71"/>
+        <line num="169" type="stmt" count="1"/>
+        <line num="170" type="stmt" count="1"/>
+        <line num="172" type="stmt" count="70"/>
+        <line num="184" type="method" name="setAppGroup" visibility="public" complexity="2" crap="2" count="2"/>
+        <line num="186" type="stmt" count="2"/>
+        <line num="187" type="stmt" count="1"/>
+        <line num="188" type="stmt" count="1"/>
+        <line num="191" type="stmt" count="1"/>
+        <line num="193" type="stmt" count="1"/>
+        <line num="202" type="method" name="getAppGroup" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="204" type="stmt" count="1"/>
+        <line num="218" type="method" name="setChannels" visibility="public" complexity="2" crap="2" count="2"/>
+        <line num="221" type="stmt" count="2"/>
+        <line num="222" type="stmt" count="2"/>
+        <line num="225" type="stmt" count="1"/>
+        <line num="227" type="stmt" count="1"/>
+        <line num="239" type="method" name="setChannel" visibility="public" complexity="1" crap="1" count="2"/>
+        <line num="241" type="stmt" count="2"/>
+        <line num="243" type="stmt" count="2"/>
+        <line num="252" type="method" name="getChannels" visibility="public" complexity="1" crap="1" count="16"/>
+        <line num="254" type="stmt" count="16"/>
+        <line num="268" type="method" name="setAliases" visibility="public" complexity="2" crap="2" count="2"/>
+        <line num="271" type="stmt" count="2"/>
+        <line num="272" type="stmt" count="2"/>
+        <line num="275" type="stmt" count="1"/>
+        <line num="277" type="stmt" count="1"/>
+        <line num="290" type="method" name="setAlias" visibility="public" complexity="1" crap="1" count="2"/>
+        <line num="292" type="stmt" count="2"/>
+        <line num="294" type="stmt" count="2"/>
+        <line num="303" type="method" name="getAliases" visibility="public" complexity="1" crap="1" count="16"/>
+        <line num="305" type="stmt" count="16"/>
+        <line num="317" type="method" name="setMessage" visibility="public" complexity="1" crap="1" count="6"/>
+        <line num="319" type="stmt" count="6"/>
+        <line num="321" type="stmt" count="6"/>
+        <line num="330" type="method" name="getMessage" visibility="public" complexity="1" crap="1" count="16"/>
+        <line num="332" type="stmt" count="16"/>
+        <line num="347" type="method" name="setExtra" visibility="public" complexity="1" crap="1" count="6"/>
+        <line num="349" type="stmt" count="6"/>
+        <line num="351" type="stmt" count="4"/>
+        <line num="353" type="stmt" count="4"/>
+        <line num="366" type="method" name="validateExtra" visibility="protected" complexity="4" crap="4" count="8"/>
+        <line num="368" type="stmt" count="8"/>
+        <line num="371" type="stmt" count="8"/>
+        <line num="372" type="stmt" count="8"/>
+        <line num="373" type="stmt" count="2"/>
+        <line num="376" type="stmt" count="6"/>
+        <line num="377" type="stmt" count="6"/>
+        <line num="380" type="stmt" count="6"/>
+        <line num="393" type="method" name="setAndroidData" visibility="public" complexity="1" crap="1" count="3"/>
+        <line num="395" type="stmt" count="3"/>
+        <line num="397" type="stmt" count="3"/>
+        <line num="399" type="stmt" count="3"/>
+        <line num="408" type="method" name="getAndroidData" visibility="public" complexity="1" crap="1" count="2"/>
+        <line num="410" type="stmt" count="2"/>
+        <line num="419" type="method" name="getExtra" visibility="public" complexity="1" crap="1" count="15"/>
+        <line num="421" type="stmt" count="15"/>
+        <line num="434" type="method" name="setIOSBadge" visibility="public" complexity="2" crap="2" count="5"/>
+        <line num="436" type="stmt" count="5"/>
+        <line num="437" type="stmt" count="2"/>
+        <line num="440" type="stmt" count="3"/>
+        <line num="442" type="stmt" count="3"/>
+        <line num="451" type="method" name="getIOSBadge" visibility="public" complexity="1" crap="1" count="24"/>
+        <line num="453" type="stmt" count="24"/>
+        <line num="466" type="method" name="setSound" visibility="public" complexity="1" crap="1" count="4"/>
+        <line num="468" type="stmt" count="4"/>
+        <line num="470" type="stmt" count="4"/>
+        <line num="479" type="method" name="removeSound" visibility="public" complexity="1" crap="1" count="10"/>
+        <line num="481" type="stmt" count="10"/>
+        <line num="483" type="stmt" count="10"/>
+        <line num="492" type="method" name="getSound" visibility="public" complexity="1" crap="1" count="16"/>
+        <line num="494" type="stmt" count="16"/>
+        <line num="506" type="method" name="setIosContentAvailable" visibility="public" complexity="1" crap="1" count="3"/>
+        <line num="508" type="stmt" count="3"/>
+        <line num="510" type="stmt" count="3"/>
+        <line num="519" type="method" name="isIosContentAvailable" visibility="public" complexity="1" crap="1" count="15"/>
+        <line num="521" type="stmt" count="15"/>
+        <line num="531" type="method" name="setAndroidDeliveryPriorityNormal" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="533" type="stmt" count="1"/>
+        <line num="535" type="stmt" count="1"/>
+        <line num="545" type="method" name="setAndroidDeliveryPriorityHigh" visibility="public" complexity="1" crap="1" count="2"/>
+        <line num="547" type="stmt" count="2"/>
+        <line num="549" type="stmt" count="2"/>
+        <line num="559" type="method" name="getAndroidDeliveryPriority" visibility="public" complexity="1" crap="1" count="16"/>
+        <line num="561" type="stmt" count="16"/>
+        <line num="570" type="method" name="getInstance" visibility="public" complexity="1" crap="1" count="1"/>
+        <line num="572" type="stmt" count="1"/>
+        <line num="582" type="method" name="getAndroidVisibility" visibility="public" complexity="1" crap="1" count="16"/>
+        <line num="584" type="stmt" count="16"/>
+        <line num="600" type="method" name="setAndroidVisibility" visibility="public" complexity="2" crap="2" count="2"/>
+        <line num="603" type="stmt" count="2"/>
+        <line num="604" type="stmt" count="2"/>
+        <line num="605" type="stmt" count="2"/>
+        <line num="608" type="stmt" count="2"/>
+        <line num="609" type="stmt" count="1"/>
+        <line num="612" type="stmt" count="1"/>
+        <line num="614" type="stmt" count="1"/>
+        <line num="644" type="method" name="setAndroidStyle" visibility="public" complexity="10" crap="10.08" count="7"/>
+        <line num="647" type="stmt" count="7"/>
+        <line num="648" type="stmt" count="7"/>
+        <line num="649" type="stmt" count="7"/>
+        <line num="652" type="stmt" count="7"/>
+        <line num="653" type="stmt" count="1"/>
+        <line num="656" type="stmt" count="6"/>
+        <line num="659" type="stmt" count="6"/>
+        <line num="660" type="stmt" count="4"/>
+        <line num="661" type="stmt" count="4"/>
+        <line num="664" type="stmt" count="2"/>
+        <line num="665" type="stmt" count="1"/>
+        <line num="668" type="stmt" count="1"/>
+        <line num="669" type="stmt" count="1"/>
+        <line num="670" type="stmt" count="1"/>
+        <line num="678" type="stmt" count="3"/>
+        <line num="679" type="stmt" count="3"/>
+        <line num="684" type="stmt" count="3"/>
         <line num="685" type="stmt" count="0"/>
-        <line num="689" type="stmt" count="0"/>
+        <line num="689" type="stmt" count="3"/>
         <line num="690" type="stmt" count="0"/>
-        <line num="693" type="stmt" count="0"/>
-        <line num="695" type="stmt" count="0"/>
-        <line num="705" type="method" name="getAndroidStyle" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="707" type="stmt" count="1"/>
-        <metrics loc="709" ncloc="334" classes="1" methods="31" coveredmethods="12" conditionals="0" coveredconditionals="0" statements="104" coveredstatements="23" elements="135" coveredelements="35"/>
+        <line num="693" type="stmt" count="3"/>
+        <line num="695" type="stmt" count="3"/>
+        <line num="705" type="method" name="getAndroidStyle" visibility="public" complexity="1" crap="1" count="18"/>
+        <line num="707" type="stmt" count="18"/>
+        <metrics loc="709" ncloc="334" classes="1" methods="31" coveredmethods="30" conditionals="0" coveredconditionals="0" statements="104" coveredstatements="102" elements="135" coveredelements="132"/>
       </file>
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Providers/UrbanAirshipV3.php">
         <class name="UrbanAirshipV3" namespace="Nodes\Push\Providers">
-          <metrics complexity="64" methods="7" coveredmethods="7" conditionals="0" coveredconditionals="0" statements="47" coveredstatements="47" elements="54" coveredelements="54"/>
+          <metrics complexity="64" methods="15" coveredmethods="15" conditionals="0" coveredconditionals="0" statements="106" coveredstatements="106" elements="121" coveredelements="121"/>
         </class>
-        <line num="37" type="method" name="setIOSBadge" visibility="public" complexity="9" crap="9" count="1"/>
-        <line num="40" type="stmt" count="1"/>
-        <line num="41" type="stmt" count="1"/>
-        <line num="44" type="stmt" count="1"/>
-        <line num="48" type="stmt" count="1"/>
-        <line num="52" type="stmt" count="1"/>
-        <line num="54" type="stmt" count="1"/>
-        <line num="264" type="method" name="buildPushData" visibility="protected" complexity="5" crap="5" count="1"/>
-        <line num="267" type="stmt" count="1"/>
-        <line num="270" type="stmt" count="1"/>
-        <line num="273" type="stmt" count="1"/>
-        <line num="276" type="stmt" count="1"/>
-        <line num="277" type="stmt" count="1"/>
-        <line num="281" type="stmt" count="1"/>
-        <line num="282" type="stmt" count="1"/>
-        <line num="286" type="stmt" count="1"/>
-        <line num="291" type="stmt" count="1"/>
-        <line num="293" type="stmt" count="1"/>
-        <line num="302" type="method" name="buildAudienceData" visibility="protected" complexity="4" crap="4" count="1"/>
-        <line num="305" type="stmt" count="1"/>
-        <line num="308" type="stmt" count="1"/>
-        <line num="313" type="stmt" count="1"/>
-        <line num="319" type="stmt" count="1"/>
-        <line num="328" type="method" name="buildIOSData" visibility="protected" complexity="5" crap="5" count="1"/>
-        <line num="331" type="stmt" count="1"/>
-        <line num="334" type="stmt" count="1"/>
-        <line num="339" type="stmt" count="1"/>
-        <line num="340" type="stmt" count="1"/>
-        <line num="344" type="stmt" count="1"/>
-        <line num="345" type="stmt" count="1"/>
-        <line num="349" type="stmt" count="1"/>
-        <line num="350" type="stmt" count="1"/>
-        <line num="351" type="stmt" count="1"/>
-        <line num="352" type="stmt" count="1"/>
-        <line num="355" type="stmt" count="1"/>
-        <line num="364" type="method" name="buildAndroidData" visibility="protected" complexity="7" crap="7" count="1"/>
-        <line num="367" type="stmt" count="1"/>
-        <line num="370" type="stmt" count="1"/>
-        <line num="375" type="stmt" count="1"/>
-        <line num="384" type="stmt" count="1"/>
-        <line num="385" type="stmt" count="1"/>
-        <line num="389" type="stmt" count="1"/>
-        <line num="394" type="stmt" count="1"/>
-        <line num="397" type="stmt" count="1"/>
-        <line num="401" type="stmt" count="1"/>
-        <line num="410" type="method" name="buildWnsData" visibility="protected" complexity="3" crap="3" count="1"/>
-        <line num="413" type="stmt" count="1"/>
-        <line num="416" type="stmt" count="1"/>
-        <line num="419" type="stmt" count="1"/>
-        <line num="420" type="stmt" count="1"/>
-        <line num="426" type="stmt" count="1"/>
-        <line num="432" type="stmt" count="1"/>
-        <line num="441" type="method" name="getRequestData" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="443" type="stmt" count="1"/>
-        <metrics loc="462" ncloc="261" classes="1" methods="7" coveredmethods="7" conditionals="0" coveredconditionals="0" statements="47" coveredstatements="47" elements="54" coveredelements="54"/>
+        <line num="37" type="method" name="setIOSBadge" visibility="public" complexity="9" crap="9" count="12"/>
+        <line num="40" type="stmt" count="12"/>
+        <line num="41" type="stmt" count="4"/>
+        <line num="44" type="stmt" count="12"/>
+        <line num="45" type="stmt" count="1"/>
+        <line num="48" type="stmt" count="11"/>
+        <line num="49" type="stmt" count="2"/>
+        <line num="52" type="stmt" count="9"/>
+        <line num="54" type="stmt" count="9"/>
+        <line num="67" type="method" name="setExtra" visibility="public" complexity="1" crap="1" count="4"/>
+        <line num="69" type="stmt" count="4"/>
+        <line num="71" type="stmt" count="3"/>
+        <line num="83" type="method" name="setAndroidData" visibility="public" complexity="1" crap="1" count="2"/>
+        <line num="85" type="stmt" count="2"/>
+        <line num="87" type="stmt" count="2"/>
+        <line num="98" type="method" name="validateExtra" visibility="protected" complexity="3" crap="3" count="5"/>
+        <line num="101" type="stmt" count="5"/>
+        <line num="106" type="stmt" count="5"/>
+        <line num="107" type="stmt" count="5"/>
+        <line num="108" type="stmt" count="5"/>
+        <line num="112" type="stmt" count="4"/>
+        <line num="113" type="stmt" count="4"/>
+        <line num="124" type="method" name="send" visibility="public" complexity="12" crap="12" count="5"/>
+        <line num="126" type="stmt" count="5"/>
+        <line num="128" type="stmt" count="4"/>
+        <line num="132" type="stmt" count="4"/>
+        <line num="135" type="stmt" count="4"/>
+        <line num="142" type="stmt" count="4"/>
+        <line num="143" type="stmt" count="4"/>
+        <line num="146" type="stmt" count="4"/>
+        <line num="147" type="stmt" count="1"/>
+        <line num="153" type="stmt" count="4"/>
+        <line num="156" type="stmt" count="3"/>
+        <line num="161" type="stmt" count="3"/>
+        <line num="164" type="stmt" count="3"/>
+        <line num="168" type="stmt" count="3"/>
+        <line num="169" type="stmt" count="1"/>
+        <line num="180" type="stmt" count="1"/>
+        <line num="181" type="stmt" count="4"/>
+        <line num="185" type="stmt" count="3"/>
+        <line num="196" type="method" name="validateBeforePush" visibility="protected" complexity="5" crap="5" count="5"/>
+        <line num="198" type="stmt" count="5"/>
+        <line num="199" type="stmt" count="1"/>
+        <line num="203" type="stmt" count="4"/>
+        <line num="207" type="stmt" count="4"/>
+        <line num="211" type="stmt" count="4"/>
+        <line num="214" type="stmt" count="4"/>
+        <line num="223" type="method" name="hasEmptyCredentials" visibility="protected" complexity="4" crap="4" count="4"/>
+        <line num="227" type="stmt" count="4"/>
+        <line num="228" type="stmt" count="4"/>
+        <line num="233" type="stmt" count="4"/>
+        <line num="242" type="method" name="getHttpClient" visibility="protected" complexity="2" crap="2" count="4"/>
+        <line num="244" type="stmt" count="4"/>
+        <line num="248" type="stmt" count="4"/>
+        <line num="249" type="stmt" count="4"/>
+        <line num="251" type="stmt" count="4"/>
+        <line num="252" type="stmt" count="4"/>
+        <line num="254" type="stmt" count="4"/>
+        <line num="264" type="method" name="buildPushData" visibility="protected" complexity="5" crap="5" count="14"/>
+        <line num="267" type="stmt" count="14"/>
+        <line num="270" type="stmt" count="14"/>
+        <line num="273" type="stmt" count="14"/>
+        <line num="276" type="stmt" count="14"/>
+        <line num="277" type="stmt" count="9"/>
+        <line num="281" type="stmt" count="14"/>
+        <line num="282" type="stmt" count="14"/>
+        <line num="286" type="stmt" count="14"/>
+        <line num="287" type="stmt" count="2"/>
+        <line num="291" type="stmt" count="14"/>
+        <line num="293" type="stmt" count="14"/>
+        <line num="302" type="method" name="buildAudienceData" visibility="protected" complexity="4" crap="4" count="14"/>
+        <line num="305" type="stmt" count="14"/>
+        <line num="308" type="stmt" count="14"/>
+        <line num="309" type="stmt" count="1"/>
+        <line num="313" type="stmt" count="14"/>
+        <line num="314" type="stmt" count="1"/>
+        <line num="315" type="stmt" count="1"/>
+        <line num="319" type="stmt" count="14"/>
+        <line num="328" type="method" name="buildIOSData" visibility="protected" complexity="5" crap="5" count="14"/>
+        <line num="331" type="stmt" count="14"/>
+        <line num="334" type="stmt" count="14"/>
+        <line num="335" type="stmt" count="2"/>
+        <line num="339" type="stmt" count="14"/>
+        <line num="340" type="stmt" count="2"/>
+        <line num="344" type="stmt" count="14"/>
+        <line num="345" type="stmt" count="6"/>
+        <line num="349" type="stmt" count="14"/>
+        <line num="350" type="stmt" count="2"/>
+        <line num="351" type="stmt" count="2"/>
+        <line num="352" type="stmt" count="2"/>
+        <line num="355" type="stmt" count="14"/>
+        <line num="364" type="method" name="buildAndroidData" visibility="protected" complexity="7" crap="7" count="14"/>
+        <line num="367" type="stmt" count="14"/>
+        <line num="370" type="stmt" count="14"/>
+        <line num="371" type="stmt" count="2"/>
+        <line num="375" type="stmt" count="14"/>
+        <line num="376" type="stmt" count="1"/>
+        <line num="379" type="stmt" count="1"/>
+        <line num="384" type="stmt" count="14"/>
+        <line num="385" type="stmt" count="6"/>
+        <line num="389" type="stmt" count="14"/>
+        <line num="390" type="stmt" count="1"/>
+        <line num="394" type="stmt" count="14"/>
+        <line num="397" type="stmt" count="14"/>
+        <line num="401" type="stmt" count="14"/>
+        <line num="410" type="method" name="buildWnsData" visibility="protected" complexity="3" crap="3" count="14"/>
+        <line num="413" type="stmt" count="14"/>
+        <line num="416" type="stmt" count="14"/>
+        <line num="419" type="stmt" count="14"/>
+        <line num="420" type="stmt" count="6"/>
+        <line num="426" type="stmt" count="14"/>
+        <line num="427" type="stmt" count="2"/>
+        <line num="428" type="stmt" count="2"/>
+        <line num="429" type="stmt" count="2"/>
+        <line num="432" type="stmt" count="14"/>
+        <line num="441" type="method" name="getRequestData" visibility="public" complexity="1" crap="1" count="10"/>
+        <line num="443" type="stmt" count="10"/>
+        <line num="453" type="method" name="setMessage" visibility="public" complexity="2" crap="2" count="5"/>
+        <line num="456" type="stmt" count="5"/>
+        <line num="457" type="stmt" count="1"/>
+        <line num="460" type="stmt" count="5"/>
+        <metrics loc="462" ncloc="261" classes="1" methods="15" coveredmethods="15" conditionals="0" coveredconditionals="0" statements="106" coveredstatements="106" elements="121" coveredelements="121"/>
       </file>
     </package>
     <package name="Nodes\Push">
@@ -256,35 +335,39 @@
         <class name="ServiceProvider" namespace="Nodes\Push">
           <metrics complexity="6" methods="5" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="10" coveredstatements="10" elements="15" coveredelements="15"/>
         </class>
-        <line num="20" type="method" name="boot" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="22" type="stmt" count="1"/>
-        <line num="23" type="stmt" count="1"/>
-        <line num="31" type="method" name="register" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="33" type="stmt" count="1"/>
-        <line num="34" type="stmt" count="1"/>
-        <line num="42" type="method" name="publishGroups" visibility="protected" complexity="1" crap="1" count="1"/>
-        <line num="45" type="stmt" count="1"/>
-        <line num="46" type="stmt" count="1"/>
-        <line num="47" type="stmt" count="1"/>
-        <line num="48" type="stmt" count="1"/>
-        <line num="56" type="method" name="registerPushProvider" visibility="protected" complexity="2" crap="2" count="1"/>
-        <line num="68" type="stmt" count="1"/>
-        <line num="70" type="method" name="anonymous function" complexity="1" crap="1" count="1"/>
-        <line num="72" type="stmt" count="1"/>
-        <line num="73" type="stmt" count="1"/>
+        <line num="20" type="method" name="boot" visibility="public" complexity="1" crap="1" count="76"/>
+        <line num="22" type="stmt" count="76"/>
+        <line num="23" type="stmt" count="76"/>
+        <line num="31" type="method" name="register" visibility="public" complexity="1" crap="1" count="76"/>
+        <line num="33" type="stmt" count="76"/>
+        <line num="34" type="stmt" count="76"/>
+        <line num="42" type="method" name="publishGroups" visibility="protected" complexity="1" crap="1" count="76"/>
+        <line num="45" type="stmt" count="76"/>
+        <line num="46" type="stmt" count="76"/>
+        <line num="47" type="stmt" count="76"/>
+        <line num="48" type="stmt" count="76"/>
+        <line num="56" type="method" name="registerPushProvider" visibility="protected" complexity="2" crap="2" count="76"/>
+        <line num="68" type="stmt" count="76"/>
+        <line num="70" type="method" name="anonymous function" complexity="1" crap="1" count="76"/>
+        <line num="72" type="stmt" count="76"/>
+        <line num="73" type="stmt" count="76"/>
         <metrics loc="87" ncloc="30" classes="1" methods="5" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="11" coveredstatements="11" elements="16" coveredelements="16"/>
       </file>
     </package>
     <package name="Nodes\Push\Support\Facades">
       <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Support/Facades/Push.php">
         <class name="Push" namespace="Nodes\Push\Support\Facades">
-          <metrics complexity="1" methods="1" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="1" coveredstatements="0" elements="2" coveredelements="0"/>
+          <metrics complexity="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="1" coveredstatements="1" elements="2" coveredelements="2"/>
         </class>
-        <line num="20" type="method" name="getFacadeAccessor" visibility="protected" complexity="1" crap="2" count="0"/>
-        <line num="22" type="stmt" count="0"/>
-        <metrics loc="24" ncloc="13" classes="1" methods="1" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="1" coveredstatements="0" elements="2" coveredelements="0"/>
+        <line num="20" type="method" name="getFacadeAccessor" visibility="protected" complexity="1" crap="1" count="1"/>
+        <line num="22" type="stmt" count="1"/>
+        <metrics loc="24" ncloc="13" classes="1" methods="1" coveredmethods="1" conditionals="0" coveredconditionals="0" statements="1" coveredstatements="1" elements="2" coveredelements="2"/>
       </file>
     </package>
-    <metrics files="11" loc="1444" ncloc="737" classes="11" methods="45" coveredmethods="24" conditionals="0" coveredconditionals="0" statements="165" coveredstatements="81" elements="210" coveredelements="105"/>
+    <file name="/var/www/riide/htdocs/vendor/nodes/push/src/Support/Helpers/Push.php">
+      <line num="14" type="stmt" count="1"/>
+      <metrics loc="16" ncloc="10" classes="0" methods="0" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="1" coveredstatements="1" elements="1" coveredelements="1"/>
+    </file>
+    <metrics files="12" loc="1460" ncloc="747" classes="11" methods="57" coveredmethods="56" conditionals="0" coveredconditionals="0" statements="233" coveredstatements="231" elements="290" coveredelements="287"/>
   </project>
 </coverage>

--- a/src/Providers/UrbanAirshipV3.php
+++ b/src/Providers/UrbanAirshipV3.php
@@ -348,6 +348,8 @@ class UrbanAirshipV3 extends AbstractProvider
         // Set Content-Available for push notification
         if ($this->isIosContentAvailable()) {
             $ios['content-available'] = $this->isIosContentAvailable();
+            unset($ios['badge']);
+            unset($ios['sound']);
         }
 
         return $ios;

--- a/tests/Providers/UrbanAirshipV3Test.php
+++ b/tests/Providers/UrbanAirshipV3Test.php
@@ -155,6 +155,30 @@ class UrbanAirshipV3Test extends TestCase
         ], $requestData);
     }
 
+    public function testGetRequestDataContentAvailableRemovesSoundAndBadge()
+    {
+        $urbanAirshipV3 = $this->getUrbanAirshipV3Provider();
+
+        $urbanAirshipV3->setIosContentAvailable(true)->setSound('sound')->setIOSBadge('1');
+        $requestData = $urbanAirshipV3->getRequestData();
+        $this->assertSame([
+            'audience'     => 'all',
+            'notification' => [
+                'alert' => null,
+                'ios'   => [
+                    'content-available' => true,
+                ],
+                'android'   => [
+                    'extra' => [
+                        'sound' => 'sound'
+                    ],
+                    'visibility' => 1
+                ],
+            ],
+            'device_types' => 'all',
+        ], $requestData);
+    }
+
     public function testGetRequestDataChannel()
     {
         $urbanAirshipV3 = $this->getUrbanAirshipV3Provider();


### PR DESCRIPTION
Silent pushes were not working is because if you have the keys “alert” or “sound” the push notification will not be silent, it only works if those are not included in the payload. I tested with Urban Airship and thats how it worked.
