### PR TITLE
Bugfix/wns does not support named users

### DIFF
--- a/src/Exceptions/InvalidAudienceException.php
+++ b/src/Exceptions/InvalidAudienceException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Nodes\Push\Exceptions;
+
+use Nodes\Exceptions\Exception as NodesException;
+
+/**
+ * Class InvalidAudienceException.
+ */
+class InvalidAudienceException extends NodesException
+{
+    /**
+     * InvalidAudience constructor.
+     *
+     * @author Justin Busschau <jubu@nodesagency.com>
+     * @param string $message
+     */
+    public function __construct($message)
+    {
+        parent::__construct($message, 500);
+    }
+}

--- a/src/Providers/UrbanAirshipV3.php
+++ b/src/Providers/UrbanAirshipV3.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Exception\ClientException;
 use Illuminate\Support\MessageBag;
 use Nodes\Push\Contracts\ProviderInterface;
 use Nodes\Push\Exceptions\InvalidArgumentException;
+use Nodes\Push\Exceptions\InvalidAudienceException;
 use Nodes\Push\Exceptions\MissingArgumentException;
 use Nodes\Push\Exceptions\PushSizeLimitException;
 use Nodes\Push\Exceptions\SendPushFailedException;
@@ -235,6 +236,10 @@ class UrbanAirshipV3 extends AbstractProvider
     {
         if (!$this->getMessage()) {
             throw new MissingArgumentException('You have to setMessage() before sending push');
+        }
+
+        if (!empty($this->getNamedUsers()) AND !empty($this->getAliases())) {
+            throw new InvalidAudienceException('Send push to either named users or aliases - not both.');
         }
 
         // Check kb size

--- a/src/Providers/UrbanAirshipV3.php
+++ b/src/Providers/UrbanAirshipV3.php
@@ -242,10 +242,6 @@ class UrbanAirshipV3 extends AbstractProvider
             throw new InvalidAudienceException('Send push to either named users or aliases - not both.');
         }
 
-        if (in_array('wns', $this->getPlatforms()) && !empty($this->getNamedUsers())) {
-            throw new InvalidAudienceException('Push to Named Users is not supported on Windows.');
-        }
-
         // Check kb size
         if (mb_strlen(json_encode($this->buildIOSData())) > 2048) {
             throw new PushSizeLimitException(sprintf('Limit of ios is 2048b, %s was send',

--- a/src/Providers/UrbanAirshipV3.php
+++ b/src/Providers/UrbanAirshipV3.php
@@ -238,11 +238,11 @@ class UrbanAirshipV3 extends AbstractProvider
             throw new MissingArgumentException('You have to setMessage() before sending push');
         }
 
-        if (!empty($this->getNamedUsers()) AND !empty($this->getAliases())) {
+        if (!empty($this->getNamedUsers()) && !empty($this->getAliases())) {
             throw new InvalidAudienceException('Send push to either named users or aliases - not both.');
         }
 
-        if (in_array('wns', $this->getPlatforms()) AND !empty($this->getNamedUsers())) {
+        if (in_array('wns', $this->getPlatforms()) && !empty($this->getNamedUsers())) {
             throw new InvalidAudienceException('Push to Named Users is not supported on Windows.');
         }
 

--- a/src/Providers/UrbanAirshipV3.php
+++ b/src/Providers/UrbanAirshipV3.php
@@ -242,6 +242,10 @@ class UrbanAirshipV3 extends AbstractProvider
             throw new InvalidAudienceException('Send push to either named users or aliases - not both.');
         }
 
+        if (in_array('wns', $this->getPlatforms()) AND !empty($this->getNamedUsers())) {
+            throw new InvalidAudienceException('Push to Named Users is not supported on Windows.');
+        }
+
         // Check kb size
         if (mb_strlen(json_encode($this->buildIOSData())) > 2048) {
             throw new PushSizeLimitException(sprintf('Limit of ios is 2048b, %s was send',

--- a/tests/Providers/UrbanAirshipV3Test.php
+++ b/tests/Providers/UrbanAirshipV3Test.php
@@ -288,15 +288,6 @@ class UrbanAirshipV3Test extends TestCase
         ], $requestData);
     }
 
-    public function testSendToNamedUserOnWindows()
-    {
-        $urbanAirshipV3 = $this->getUrbanAirshipV3Provider();
-        $urbanAirshipV3->setNamedUser(uniqid());
-        $urbanAirshipV3->setMessage('nodes/push php package - unittest - ' . __METHOD__);
-        $this->expectException(InvalidAudienceException::class);
-        $urbanAirshipV3->send();
-    }
-
     public function testGetRequestDataMessage()
     {
         $urbanAirshipV3 = $this->getUrbanAirshipV3Provider();

--- a/tests/Providers/UrbanAirshipV3Test.php
+++ b/tests/Providers/UrbanAirshipV3Test.php
@@ -372,6 +372,16 @@ class UrbanAirshipV3Test extends TestCase
         $this->assertTrue(!empty($result[0]['ok']) && $result[0]['ok']);
     }
 
+    public function testSendToNamedUsersAndAliases()
+    {
+        $urbanAirshipV3 = $this->getUrbanAirshipV3Provider();
+        $urbanAirshipV3->setMessage('nodes/push php package - unit test - ' . __METHOD__);
+        $urbanAirshipV3->setNamedUser(uniqid());
+        $urbanAirshipV3->setAlias(uniqid());
+        $this->expectException(\Throwable::class);
+        $urbanAirshipV3->send();
+    }
+
     public function testSendProxy()
     {
         $urbanAirshipV3 = $this->getUrbanAirshipV3WithProxyProvider();

--- a/tests/Providers/UrbanAirshipV3Test.php
+++ b/tests/Providers/UrbanAirshipV3Test.php
@@ -288,6 +288,15 @@ class UrbanAirshipV3Test extends TestCase
         ], $requestData);
     }
 
+    public function testSendToNamedUserOnWindows()
+    {
+        $urbanAirshipV3 = $this->getUrbanAirshipV3Provider();
+        $urbanAirshipV3->setNamedUser(uniqid());
+        $urbanAirshipV3->setMessage('nodes/push php package - unittest - ' . __METHOD__);
+        $this->expectException(InvalidAudienceException::class);
+        $urbanAirshipV3->send();
+    }
+
     public function testGetRequestDataMessage()
     {
         $urbanAirshipV3 = $this->getUrbanAirshipV3Provider();

--- a/tests/Providers/UrbanAirshipV3Test.php
+++ b/tests/Providers/UrbanAirshipV3Test.php
@@ -5,6 +5,7 @@ namespace Nodes\Push\Tests\Providers;
 use Carbon\Carbon;
 use Nodes\Push\Constants\AndroidSettings;
 use Nodes\Push\Exceptions\InvalidArgumentException;
+use Nodes\Push\Exceptions\InvalidAudienceException;
 use Nodes\Push\Exceptions\MissingArgumentException;
 use Nodes\Push\Exceptions\PushSizeLimitException;
 use Nodes\Push\Exceptions\SendPushFailedException;
@@ -378,7 +379,7 @@ class UrbanAirshipV3Test extends TestCase
         $urbanAirshipV3->setMessage('nodes/push php package - unit test - ' . __METHOD__);
         $urbanAirshipV3->setNamedUser(uniqid());
         $urbanAirshipV3->setAlias(uniqid());
-        $this->expectException(\Throwable::class);
+        $this->expectException(InvalidAudienceException::class);
         $urbanAirshipV3->send();
     }
 


### PR DESCRIPTION
While switching over to Named Users from Aliases, we will need to enforce using either one or the other. If you need to push to a mixture of Named Users and Aliases, you will need to make two calls, one to the Aliases and a separate one to the Named Users.

In addition, Windows (wns) does not currently support Named Users, so an exception will be thrown if you attempt to send to wns targets using Named Users.